### PR TITLE
Fix GHC 9.0 Compatibility

### DIFF
--- a/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
+++ b/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
 
 -- |
 -- Module      : Data.Functor.ProductIsomorphic.TH.Internal
@@ -44,7 +45,11 @@ recordInfo' =  d  where
         where (ns, ts) = unzip [(n, return t) | (n, _, t) <- vts]
       _                -> Nothing
   d _                  =  Nothing
+#if MIN_VERSION_base(4,15,0)
+  getTV (PlainTV n _)    =  n
+#else
   getTV (PlainTV n)    =  n
+#endif
   getTV (KindedTV n _) =  n
   buildT tcn vns = foldl' appT (conT tcn) [ varT vn | vn <- vns ]
 

--- a/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
+++ b/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
@@ -47,10 +47,11 @@ recordInfo' =  d  where
   d _                  =  Nothing
 #if MIN_VERSION_base(4,15,0)
   getTV (PlainTV n _)    =  n
+  getTV (KindedTV n _) =  n
 #else
   getTV (PlainTV n)    =  n
+  getTV (KindedTV n _ _) =  n
 #endif
-  getTV (KindedTV n _) =  n
   buildT tcn vns = foldl' appT (conT tcn) [ varT vn | vn <- vns ]
 
 -- | Low-level reify interface for record type name.

--- a/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
+++ b/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
@@ -47,10 +47,10 @@ recordInfo' =  d  where
   d _                  =  Nothing
 #if MIN_VERSION_base(4,15,0)
   getTV (PlainTV n _)    =  n
-  getTV (KindedTV n _) =  n
-#else
-  getTV (PlainTV n)    =  n
   getTV (KindedTV n _ _) =  n
+#else
+  getTV (PlainTV n)  =  n
+  getTV (KindedTV n _) =  n
 #endif
   buildT tcn vns = foldl' appT (conT tcn) [ varT vn | vn <- vns ]
 


### PR DESCRIPTION
In GHC 9.0.1 PlainTV and KindedTV got an extra `flag` argument. They don't have record names to pattern match on so I added a C preprocessor statement to ignore the flags.