### PR TITLE
Build with GHC 9.4

### DIFF
--- a/product-isomorphic.cabal
+++ b/product-isomorphic.cabal
@@ -42,6 +42,7 @@ library
   build-depends:       base >=4.5 && <5
                      , template-haskell
                      , th-data-compat
+                     , th-abstraction
   if impl(ghc == 7.4.*)
     build-depends:        ghc-prim == 0.2.*
   hs-source-dirs:      src

--- a/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
+++ b/src/Data/Functor/ProductIsomorphic/TH/Internal.hs
@@ -23,6 +23,7 @@ import Language.Haskell.TH
    TypeQ, arrowT, appT, conT, varT,
    Dec, ExpQ, conE, Con (..), TyVarBndr (..), nameBase,)
 import Language.Haskell.TH.Compat.Data (unDataD, unNewtypeD)
+import Language.Haskell.TH.Datatype.TyVarBndr (tvName)
 import Data.List (foldl')
 
 import Data.Functor.ProductIsomorphic.Unsafe (ProductConstructor (..))
@@ -37,15 +38,13 @@ recordInfo' =  d  where
       <|>
       do (_cxt, tcn, bs, _mk,  r , _ds)  <-  unNewtypeD tcon
          Just (tcn, bs, r)
-    let vns = map getTV bs
+    let vns = map tvName bs
     case r of
       NormalC dcn ts   -> Just (((buildT tcn vns, vns), conE dcn), (Nothing, [return t | (_, t) <- ts]))
       RecC    dcn vts  -> Just (((buildT tcn vns, vns), conE dcn), (Just ns, ts))
         where (ns, ts) = unzip [(n, return t) | (n, _, t) <- vts]
       _                -> Nothing
   d _                  =  Nothing
-  getTV (PlainTV n)    =  n
-  getTV (KindedTV n _) =  n
   buildT tcn vns = foldl' appT (conT tcn) [ varT vn | vn <- vns ]
 
 -- | Low-level reify interface for record type name.


### PR DESCRIPTION
template-haskell-2.16.0.0 added a type variable `flag` to `PlainTV` and `KindTV`. [The `tvName` function of the th-abstraction](https://hackage.haskell.org/package/th-abstraction-0.6.0.0/docs/Language-Haskell-TH-Datatype-TyVarBndr.html#v:tvName) abstracts the difference between the versions of template-haskell.